### PR TITLE
Remove code comparing plain text passwords

### DIFF
--- a/lib/hexpm/accounts/auth.ex
+++ b/lib/hexpm/accounts/auth.ex
@@ -61,7 +61,7 @@ defmodule Hexpm.Accounts.Auth do
 
     valid_user = user && !User.organization?(user) && user.password
 
-    if valid_user && password == user.password do
+    if valid_user && Bcrypt.verify_pass(password, user.password) do
       {:ok,
        %{
          key: nil,


### PR DESCRIPTION
This PR fixes the snippet in user authentication logic that was trying to check user passwords by comparing them as plain text rather than using the dedicated functions of the `bcrypt_elixir` library.